### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Swift Multiaddr
 [![](https://img.shields.io/badge/project-multiformats-blue.svg?style=flat-square)](http://github.com/multiformats/multiformats)
 [![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
 
-> A [Multiaddr](https://github.com/jbenet/multiaddr) implementation in Swift.
+> A [Multiaddr](https://github.com/multiformats/multiaddr) implementation in Swift.
 
 ## Table of Contents
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein
### GitHub Corrected URLs

| Was | Now |
| --- | --- |
| https://github.com/jbenet/multiaddr | https://github.com/multiformats/multiaddr |
