### PR TITLE
Attempt at modernizing code and adding safety

### DIFF
--- a/SwiftMultiaddr/MultiAddr.swift
+++ b/SwiftMultiaddr/MultiAddr.swift
@@ -11,15 +11,19 @@ import Foundation
 public struct Multiaddr: Equatable {
     public private(set) var bytes: [UInt8]
 
-    // MARK: - Constructors
-    public static func newMultiaddr(_ addrString: String) throws -> Multiaddr {
-        let multiaddressBytes = try stringToBytes(addrString)
-        return Multiaddr(bytes: multiaddressBytes)
+    // MARK: - Initializers
+    private init(bytes: [UInt8]) {
+        self.bytes = bytes
     }
 
-    public static func newMultiaddrBytes(_ address: [UInt8]) throws -> Multiaddr {
+    public init(address: String) throws {
+        let multiaddressBytes = try stringToBytes(address)
+        self.init(bytes: multiaddressBytes)
+    }
+
+    public init(address: [UInt8]) throws {
         let addressString = try bytesToString(address)
-        return try newMultiaddr(addressString)
+        try self.init(address: addressString)
     }
 }
 
@@ -63,6 +67,6 @@ extension Multiaddr {
             return Multiaddr(bytes: bytes)
         }
 
-        return try Multiaddr.newMultiaddr(String(oldString[..<range.lowerBound]))
+        return try .init(address: String(oldString[..<range.lowerBound]))
     }
 }

--- a/SwiftMultiaddrTests/CodecTests.swift
+++ b/SwiftMultiaddrTests/CodecTests.swift
@@ -11,44 +11,29 @@ import XCTest
 import SwiftHex
 
 class CodecTests: XCTestCase {
-    
-    func testStringToBytes() {
-        
+    func testStringToBytes() throws {
         let testString = { (address: String, hex: String) in
             let decodedHex = try SwiftHex.decodeString(hexString: hex)
             let encodedAddress = try stringToBytes(address)
             
-            XCTAssert(decodedHex == encodedAddress)
+            XCTAssertEqual(decodedHex, encodedAddress)
         }
-    
-        
-        do {
-            try testString("/ip4/127.0.0.1/udp/1234", "047f0000011104d2")
-            try testString("/ip4/127.0.0.1/tcp/4321", "047f0000010610e1")
-            try testString("/ip4/127.0.0.1/udp/1234/ip4/127.0.0.1/tcp/4321", "047f0000011104d2047f0000010610e1")
-        } catch {
-            print(error)
-            XCTFail()
-        }
+
+        try testString("/ip4/127.0.0.1/udp/1234", "047f0000011104d2")
+        try testString("/ip4/127.0.0.1/tcp/4321", "047f0000010610e1")
+        try testString("/ip4/127.0.0.1/udp/1234/ip4/127.0.0.1/tcp/4321", "047f0000011104d2047f0000010610e1")
     }
     
-    func testBytesToString() {
-        
+    func testBytesToString() throws {
         let testString = { (address: String, hex: String) in
             let decodedHex = try SwiftHex.decodeString(hexString: hex)
             let encodedAddress = try bytesToString(decodedHex)
             
-            XCTAssert(address == encodedAddress)
+            XCTAssertEqual(address, encodedAddress)
         }
-        
-        
-        do {
-            try testString("/ip4/127.0.0.1/udp/1234", "047f0000011104d2")
-            try testString("/ip4/127.0.0.1/tcp/4321", "047f0000010610e1")
-            try testString("/ip4/127.0.0.1/udp/1234/ip4/127.0.0.1/tcp/4321", "047f0000011104d2047f0000010610e1")
-        } catch {
-            print(error)
-            XCTFail()
-        }
+
+        try testString("/ip4/127.0.0.1/udp/1234", "047f0000011104d2")
+        try testString("/ip4/127.0.0.1/tcp/4321", "047f0000010610e1")
+        try testString("/ip4/127.0.0.1/udp/1234/ip4/127.0.0.1/tcp/4321", "047f0000011104d2047f0000010610e1")
     }
 }

--- a/SwiftMultiaddrTests/IpUtilTests.swift
+++ b/SwiftMultiaddrTests/IpUtilTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 class IpUtilTests: XCTestCase {
 
-    func testParseIP() {
+    func testParseIP() throws {
         
         let IPTestCases: [(input: String, output: IP)] = [
             ("127.0.1.2", IPv4(127, 0, 1, 2)),
@@ -27,7 +27,7 @@ class IpUtilTests: XCTestCase {
             ("2001:4860:0:2001::68", IP(arrayLiteral: 0x20, 0x01, 0x48, 0x60, 0, 0, 0x20, 0x01, 0, 0, 0, 0, 0, 0, 0x00, 0x68)),
             ("2001:4860:0000:2001:0000:0000:0000:0068", IP(arrayLiteral: 0x20, 0x01, 0x48, 0x60, 0, 0, 0x20, 0x01, 0, 0, 0, 0, 0, 0, 0x00, 0x68)),
             
-            /// The following should fail
+            // The following should fail
             ("127.0.0.256", IP()),
             ("abc", IP()),
             ("fe80::1%lo0", IP()),
@@ -39,12 +39,9 @@ class IpUtilTests: XCTestCase {
         for testCase in IPTestCases {
             do {
                 let out = try parseIP(testCase.input)
-                XCTAssert(out == testCase.output)
+                XCTAssertEqual(out, testCase.output)
             } catch {
-                if testCase.output != IP() {
-                    print("ERROR: ",error, "for test case",testCase.input)
-                    XCTFail()
-                }
+                XCTAssertEqual(testCase.output, IP())
             }
         }
     }

--- a/SwiftMultiaddrTests/ProtocolsTest.swift
+++ b/SwiftMultiaddrTests/ProtocolsTest.swift
@@ -12,7 +12,7 @@ import XCTest
 class ProtocolsTest: XCTestCase {
 
     func testProtocols() throws {
-        let m = try Multiaddr.newMultiaddr("/ip4/127.0.0.1/udp/1234")
+        let m = try Multiaddr(address: "/ip4/127.0.0.1/udp/1234")
         let ps = try m.protocols()
 
         XCTAssertEqual(ps[0].code, protocolWithName("ip4")?.code)

--- a/SwiftMultiaddrTests/SwiftMultiaddrTests.swift
+++ b/SwiftMultiaddrTests/SwiftMultiaddrTests.swift
@@ -69,19 +69,19 @@ class SwiftMultiaddrTests: XCTestCase {
         ]
 
         try failCases.forEach {
-            XCTAssertThrowsError(try Multiaddr.newMultiaddr($0))
+            XCTAssertThrowsError(try Multiaddr(address: $0))
         }
 
         try passCases.forEach {
-            XCTAssertNoThrow(try Multiaddr.newMultiaddr($0))
+            XCTAssertNoThrow(try Multiaddr(address: $0))
         }
     }
     
     func testEqualityConformance() throws {
-        let m1 = try Multiaddr.newMultiaddr("/ip4/127.0.0.1/udp/1234")
-        let m2 = try Multiaddr.newMultiaddr("/ip4/127.0.0.1/tcp/1234")
-        let m3 = try Multiaddr.newMultiaddr("/ip4/127.0.0.1/tcp/1234")
-        let m4 = try Multiaddr.newMultiaddr("/ip4/127.0.0.1/tcp/1234/")
+        let m1 = try Multiaddr(address: "/ip4/127.0.0.1/udp/1234")
+        let m2 = try Multiaddr(address: "/ip4/127.0.0.1/tcp/1234")
+        let m3 = try Multiaddr(address: "/ip4/127.0.0.1/tcp/1234")
+        let m4 = try Multiaddr(address: "/ip4/127.0.0.1/tcp/1234/")
 
         XCTAssertNotEqual(m1, m2)
         XCTAssertEqual(m1, m1)
@@ -91,21 +91,21 @@ class SwiftMultiaddrTests: XCTestCase {
     }
     
     func testEncapsulatingWithDecapsulating() throws {
-        let m = try Multiaddr.newMultiaddr("/ip4/127.0.0.1/udp/1234")
-        let m2 = try Multiaddr.newMultiaddr("/udp/5678")
+        let m = try Multiaddr(address:"/ip4/127.0.0.1/udp/1234")
+        let m2 = try Multiaddr(address:"/udp/5678")
 
         let b = m.encapsulate(m2)
         var s = try b.string()
 
         XCTAssertEqual(s, "/ip4/127.0.0.1/udp/1234/udp/5678", "Encapsulate /ip4/127.0.0.1/udp/1234/udp/5678 failed " + s)
 
-        let m3 = try Multiaddr.newMultiaddr("/udp/5678")
+        let m3 = try Multiaddr(address:"/udp/5678")
         let c = try b.decapsulate(m3)
         s = try c.string()
 
         XCTAssertEqual(s, "/ip4/127.0.0.1/udp/1234", "Decapsulate /udp failed. /ip4/127.0.0.1/udp/1234" + s)
 
-        let m4 = try Multiaddr.newMultiaddr("/ip4/127.0.0.1")
+        let m4 = try Multiaddr(address:"/ip4/127.0.0.1")
         XCTAssertThrowsError(try c.decapsulate(m4))
     }
 }


### PR DESCRIPTION
Hi there 👋,

while browsing through the [IPFS Swift client](https://github.com/ipfs-shipyard/swift-ipfs-http-client), I saw this is a dependency and went through the code base of this repo. I saw that the unit tests don't really follow best practices for using asserts and don't use it that test cases themselves can be marked as throwing. In the same step, I tried making the code base easier to read and maintain and started modernizing certain parts of the code base to be easier usable from the perspective of an integrator.

**A Road to Review**
0928598: mostly attempts at cleaning up the test cases by using proper XCTest asserts and by removing quite a lot of code due to manually catching throwing functions and replacing that with marking the test cases themselves as throwing.

a19ffb6: is a more broad attempt at modernizing and cleaning up the entirety of the codebase by using modern features such as HOF, safely unwrapping instead of force unwrapping in many places, removing many comments (they're still available in the source history), improving the `Multiaddr` struct by removing global functions that are accessible to integrators and nesting them into the struct itself, making use of automatically synthesized `Equatable` conformance and generally cleaning up the type. In other places I removed code that potentially terminates the execution (such as using `fatalError`).


9ef4d36: removes constructors for initializing a `Multiaddr` instance and replaces them with proper initializers.

I think these changes add quite a lot of safety to the code and make it more pleasant to use.